### PR TITLE
Race conditions in `LoadingDictionaryTests`

### DIFF
--- a/.github/workflows/nightly-prs-to-main.yml
+++ b/.github/workflows/nightly-prs-to-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-prs-to-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}
       asset-keys: '{ "DeviceDetection": "${{ secrets.DEVICE_DETECTION_KEY }}","DeviceDetectionUrl": "${{ secrets.DEVICE_DETECTION_URL }}", "TestResourceKey": "${{ secrets.SUPER_RESOURCE_KEY}}","AcceptCHBrowserKey" : "${{ secrets.ACCEPTCH_BROWSER_KEY}}","AcceptCHHardwareKey" : "${{ secrets.ACCEPTCH_HARDWARE_KEY}}","AcceptCHPlatformKey" : "${{ secrets.ACCEPTCH_PLATFORM_KEY}}","AcceptCHNoneKey" : "${{ secrets.ACCEPTCH_NONE_KEY}}" }'

--- a/.github/workflows/nightly-publish-main.yml
+++ b/.github/workflows/nightly-publish-main.yml
@@ -12,6 +12,7 @@ jobs:
     uses: 51Degrees/common-ci/.github/workflows/nightly-publish-main.yml@main
     with:
       repo-name: ${{ github.event.repository.name }}
+      org-name: ${{ github.event.repository.owner.login }}
       build-platform: windows-latest
     secrets:
       token: ${{ secrets.ACCESS_TOKEN }}

--- a/FiftyOne.Caching.Tests/Loaders/ReturnKeyLoader.cs
+++ b/FiftyOne.Caching.Tests/Loaders/ReturnKeyLoader.cs
@@ -54,9 +54,9 @@ namespace FiftyOne.Caching.Tests.Loaders
 
         public ReturnKeyLoader(
             int delayMillis,
-            Func<CancellationToken, CancellationToken> tokenForTask,
-            Func<CancellationToken, CancellationToken> tokenForLoading) :
-            base(delayMillis, tokenForTask, tokenForLoading)
+            Func<CancellationToken, CancellationToken> taskCancellationTokenProvider,
+            Func<CancellationToken, CancellationToken> loopCancellationTokenProvider) :
+            base(delayMillis, taskCancellationTokenProvider, loopCancellationTokenProvider)
         {
         }
 

--- a/FiftyOne.Caching.Tests/Loaders/ReturnKeyLoader.cs
+++ b/FiftyOne.Caching.Tests/Loaders/ReturnKeyLoader.cs
@@ -52,6 +52,14 @@ namespace FiftyOne.Caching.Tests.Loaders
         {
         }
 
+        public ReturnKeyLoader(
+            int delayMillis,
+            Func<CancellationToken, CancellationToken> tokenForTask,
+            Func<CancellationToken, CancellationToken> tokenForLoading) :
+            base(delayMillis, tokenForTask, tokenForLoading)
+        {
+        }
+
         protected override T GetValue(T key)
         {
             return key;

--- a/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
+++ b/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
@@ -133,7 +133,10 @@ namespace FiftyOne.Caching.Tests.Loaders
 
         public TValue Load(TKey key)
         {
-            Interlocked.Increment(ref _calls);
+            lock (_countersLock)
+            {
+                ++_calls;
+            }
             if (_delayMillis > 0)
             {
                 var start = DateTime.Now;

--- a/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
+++ b/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
@@ -127,14 +127,14 @@ namespace FiftyOne.Caching.Tests.Loaders
                     }
                     lock (_countersLock)
                     {
-                        if (DateTime.Now >= start.AddMilliseconds(_delayMillis))
-                        {
-                            ++_completeWaits;
-                        }
                         if (tokenForLoading.IsCancellationRequested)
                         {
                             ++_cancels;
                             throw new OperationCanceledException();
+                        }
+                        if (DateTime.Now >= start.AddMilliseconds(_delayMillis))
+                        {
+                            ++_completeWaits;
                         }
                     }
                 }

--- a/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
+++ b/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
@@ -55,6 +55,8 @@ namespace FiftyOne.Caching.Tests.Loaders
 
         private readonly Func<CancellationToken, CancellationToken> _tokenForLoading;
 
+        public event Action<TKey> OnTaskStarted;
+
         public TrackingLoaderBase() : this(0)
         {
 
@@ -114,6 +116,7 @@ namespace FiftyOne.Caching.Tests.Loaders
                 {
                     ++_taskCalls;
                 }
+                OnTaskStarted?.Invoke(key);
                 if (_delayMillis > 0)
                 {
                     var start = DateTime.Now;

--- a/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
+++ b/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
@@ -35,8 +35,6 @@ namespace FiftyOne.Caching.Tests.Loaders
 
         private int _calls = 0;
 
-        private int _taskCalls = 0;
-
         private int _cancels = 0;
 
         private int _completeWaits = 0;
@@ -44,8 +42,6 @@ namespace FiftyOne.Caching.Tests.Loaders
         private readonly object _countersLock = new object();
 
         public int Calls { get { lock (_countersLock) { return _calls; } } }
-
-        public int TaskCalls { get { lock (_countersLock) { return _taskCalls; } } }
 
         public int Cancels { get { lock (_countersLock) { return _cancels; } } }
 
@@ -110,10 +106,6 @@ namespace FiftyOne.Caching.Tests.Loaders
             var tokenForLoading = _tokenForLoading?.Invoke(token) ?? token;
             return Task.Run(() =>
             {
-                lock (_countersLock)
-                {
-                    ++_taskCalls;
-                }
                 if (_delayMillis > 0)
                 {
                     var start = DateTime.Now;

--- a/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
+++ b/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
@@ -35,6 +35,8 @@ namespace FiftyOne.Caching.Tests.Loaders
 
         private int _calls = 0;
 
+        private int _taskCalls = 0;
+
         private int _cancels = 0;
 
         private int _completeWaits = 0;
@@ -42,6 +44,8 @@ namespace FiftyOne.Caching.Tests.Loaders
         private readonly object _countersLock = new object();
 
         public int Calls { get { lock (_countersLock) { return _calls; } } }
+
+        public int TaskCalls { get { lock (_countersLock) { return _taskCalls; } } }
 
         public int Cancels { get { lock (_countersLock) { return _cancels; } } }
 
@@ -106,6 +110,10 @@ namespace FiftyOne.Caching.Tests.Loaders
             var tokenForLoading = _tokenForLoading?.Invoke(token) ?? token;
             return Task.Run(() =>
             {
+                lock (_countersLock)
+                {
+                    ++_taskCalls;
+                }
                 if (_delayMillis > 0)
                 {
                     var start = DateTime.Now;

--- a/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
+++ b/FiftyOne.Caching.Tests/Loaders/TrackingLoaderBase.cs
@@ -34,6 +34,8 @@ namespace FiftyOne.Caching.Tests.Loaders
 
         private int _calls = 0;
 
+        private int _taskCalls = 0;
+
         private int _cancels = 0;
 
         private int _completeWaits = 0;
@@ -43,6 +45,8 @@ namespace FiftyOne.Caching.Tests.Loaders
         private readonly bool _runWithToken;
 
         public int Calls { get { lock (_countersLock) { return _calls; } } }
+
+        public int TaskCalls { get { lock (_countersLock) { return _taskCalls; } } }
 
         public int Cancels { get { lock (_countersLock) { return _cancels; } } }
 
@@ -70,6 +74,10 @@ namespace FiftyOne.Caching.Tests.Loaders
             }
             return Task.Run(() =>
             {
+                lock (_countersLock)
+                {
+                    ++_taskCalls;
+                }
                 if (_delayMillis > 0)
                 {
                     var start = DateTime.Now;

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -226,9 +226,9 @@ namespace FiftyOne.Caching.Tests
         {
             // Arrange
 
-            const int loadTimeMS = 1000;
+            const int loadTimeMS = 10;
             var value = "teststring";
-            const int GATE_TIMEOUT_MS = 400;
+            const int GATE_TIMEOUT_MS = 5000;
             var sourceForLoader = new CancellationTokenSource();
             Func<CancellationToken, CancellationToken> tokenOverride = _ => sourceForLoader.Token;
             var loader = new ReturnKeyLoader<string>(loadTimeMS, tokenOverride, tokenOverride);

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -226,9 +226,9 @@ namespace FiftyOne.Caching.Tests
         {
             // Arrange
 
-            const int baseStepMS = 300;
+            const int baseStepMS = 700;
             var value = "teststring";
-            const int GATE_TIMEOUT_MS = 120;
+            const int GATE_TIMEOUT_MS = 300;
             var sourceForLoader = new CancellationTokenSource();
             Func<CancellationToken, CancellationToken> tokenOverride = _ => sourceForLoader.Token;
             var loader = new ReturnKeyLoader<string>(3 * baseStepMS, tokenOverride, tokenOverride);

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -914,6 +914,9 @@ namespace FiftyOne.Caching.Tests
             try
             {
                 getter.Wait(1000);
+                Assert.IsTrue(
+                    _token.IsCancellationRequested,
+                    $"{nameof(loader.OnTaskStarted)} has not cancelled the token source.");
                 Assert.Fail(
                     "The prior cancel of the token should prevent getting here");
             }
@@ -952,6 +955,9 @@ namespace FiftyOne.Caching.Tests
             try
             {
                 getter.Wait(1000);
+                Assert.IsTrue(
+                    _token.IsCancellationRequested, 
+                    $"{nameof(loader.OnTaskStarted)} has not cancelled the token source.");
                 Assert.Fail(
                     "The prior cancel of the token should prevent getting here");
             }

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -214,6 +214,7 @@ namespace FiftyOne.Caching.Tests
 
             var expectedCalls = expectedCallsCalculator(count);
             Assert.AreEqual(expectedCalls, loader.Calls);
+            Assert.AreEqual(expectedCalls, loader.TaskCalls);
         }
 
         [TestMethod]
@@ -270,6 +271,7 @@ namespace FiftyOne.Caching.Tests
             Assert.AreEqual(value, secondCallTask.Result);
 
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
         }
 
         /// <summary>
@@ -301,6 +303,7 @@ namespace FiftyOne.Caching.Tests
                 Assert.AreEqual(i.ToString(), results[i]);
             }
             Assert.AreEqual(10, loader.Calls);
+            Assert.AreEqual(10, loader.TaskCalls);
             Assert.AreEqual(10, dict.Keys.Count());
         }
 

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -226,12 +226,12 @@ namespace FiftyOne.Caching.Tests
         {
             // Arrange
 
-            const int baseStepMS = 400;
+            const int loadTimeMS = 1000;
             var value = "teststring";
-            const int GATE_TIMEOUT_MS = 150;
+            const int GATE_TIMEOUT_MS = 400;
             var sourceForLoader = new CancellationTokenSource();
             Func<CancellationToken, CancellationToken> tokenOverride = _ => sourceForLoader.Token;
-            var loader = new ReturnKeyLoader<string>(baseStepMS, tokenOverride, tokenOverride);
+            var loader = new ReturnKeyLoader<string>(loadTimeMS, tokenOverride, tokenOverride);
             var dict = new LoadingDictionary<string, string>(_logger.Object, loader);
             var results = new ConcurrentDictionary<int, string>();
 
@@ -285,7 +285,7 @@ namespace FiftyOne.Caching.Tests
             firstTokenCancelled.Wait(2 * GATE_TIMEOUT_MS);
             Assert.IsTrue(
                 firstTokenCancelled.IsSet,
-                $"{nameof(firstTokenCancelled)} still not set after.");
+                $"{nameof(firstTokenCancelled)} still not set.");
 
 
             // Assert

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -224,7 +224,9 @@ namespace FiftyOne.Caching.Tests
 
             const int baseStepMS = 150;
             var value = "teststring";
-            var loader = new ReturnKeyLoader<string>(3 * baseStepMS);
+            var sourceForLoader = new CancellationTokenSource();
+            Func<CancellationToken, CancellationToken> tokenOverride = _ => sourceForLoader.Token;
+            var loader = new ReturnKeyLoader<string>(3 * baseStepMS, tokenOverride, tokenOverride);
             var dict = new LoadingDictionary<string, string>(_logger.Object, loader);
             var results = new ConcurrentDictionary<int, string>();
 
@@ -266,7 +268,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.ThrowsException<AggregateException>(() => firstCallTask.Result);
-            Assert.ThrowsException<AggregateException>(() => secondCallTask.Result);
+            Assert.AreEqual(value, secondCallTask.Result);
 
             Assert.AreEqual(1, loader.Calls);
             Assert.AreEqual(1, loader.TaskCalls);

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -23,13 +23,11 @@
 using FiftyOne.Caching.Tests.Loaders;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.VisualStudio.TestTools.UnitTesting.Logging;
 using Moq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -214,7 +214,6 @@ namespace FiftyOne.Caching.Tests
 
             var expectedCalls = expectedCallsCalculator(count);
             Assert.AreEqual(expectedCalls, loader.Calls);
-            Assert.AreEqual(expectedCalls, loader.TaskCalls);
         }
 
         [TestMethod]
@@ -271,7 +270,6 @@ namespace FiftyOne.Caching.Tests
             Assert.AreEqual(value, secondCallTask.Result);
 
             Assert.AreEqual(1, loader.Calls);
-            Assert.AreEqual(1, loader.TaskCalls);
         }
 
         /// <summary>
@@ -303,7 +301,6 @@ namespace FiftyOne.Caching.Tests
                 Assert.AreEqual(i.ToString(), results[i]);
             }
             Assert.AreEqual(10, loader.Calls);
-            Assert.AreEqual(10, loader.TaskCalls);
             Assert.AreEqual(10, dict.Keys.Count());
         }
 

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -468,8 +468,8 @@ namespace FiftyOne.Caching.Tests
 
             // Act
 
+            loader.OnTaskStarted += _ => _token.Cancel();
             var getter = Task.Run(() => dict[value, _token.Token]);
-            _token.Cancel();
             try
             {
                 getter.Wait(millis * 2);
@@ -550,8 +550,8 @@ namespace FiftyOne.Caching.Tests
 
             // Act
 
+            loader.OnTaskStarted += _ => _token.Cancel();
             var getter = Task.Run(() => dict.TryGet(value, _token.Token, out _));
-            _token.Cancel();
             try
             {
                 getter.Wait(millis * 2);
@@ -770,10 +770,10 @@ namespace FiftyOne.Caching.Tests
 
             // Act
 
+            loader.OnTaskStarted += _ => _token.Cancel();
             for (int i = 0; i < count; i++)
             {
                 var getter = Task.Run(() => _ = dict[value, _token.Token]);
-                _token.Cancel();
 
                 try
                 {
@@ -846,10 +846,10 @@ namespace FiftyOne.Caching.Tests
 
             // Act
 
+            loader.OnTaskStarted += _ => _token.Cancel();
             for (int i = 0; i < count; i++)
             {
                 var getter = Task.Run(() => dict.TryGet(value, _token.Token, out _));
-                _token.Cancel();
 
                 Assert.ThrowsException<AggregateException>(() =>
                 {
@@ -909,8 +909,8 @@ namespace FiftyOne.Caching.Tests
 
             // Act
 
+            loader.OnTaskStarted += _ => _token.Cancel();
             var getter = Task.Run(() => dict[value, _token.Token]);
-            _token.Cancel();
             try
             {
                 getter.Wait(1000);
@@ -947,8 +947,8 @@ namespace FiftyOne.Caching.Tests
 
             // Act
 
+            loader.OnTaskStarted += _ => _token.Cancel();
             var getter = Task.Run(() => dict.TryGet(value, _token.Token, out _));
-            _token.Cancel();
             try
             {
                 getter.Wait(1000);

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -71,6 +71,7 @@ namespace FiftyOne.Caching.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(value, result);
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(1, dict.Keys.Count());
         }
 
@@ -97,6 +98,7 @@ namespace FiftyOne.Caching.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(value, result);
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(1, dict.Keys.Count());
         }
 
@@ -124,6 +126,7 @@ namespace FiftyOne.Caching.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(value, result);
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(1, dict.Keys.Count());
         }
 
@@ -152,6 +155,7 @@ namespace FiftyOne.Caching.Tests
             Assert.IsNotNull(result);
             Assert.AreEqual(value, result);
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(1, dict.Keys.Count());
         }
 
@@ -343,6 +347,7 @@ namespace FiftyOne.Caching.Tests
                 Assert.AreEqual(value, result.Value);
             }
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(1, dict.Keys.Count());
         }
 
@@ -379,6 +384,7 @@ namespace FiftyOne.Caching.Tests
                 Assert.AreEqual(i.ToString(), results[i]);
             }
             Assert.AreEqual(10, loader.Calls);
+            Assert.AreEqual(10, loader.TaskCalls);
             Assert.AreEqual(10, dict.Keys.Count());
         }
 
@@ -479,6 +485,8 @@ namespace FiftyOne.Caching.Tests
 
             // Assert
 
+            Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(1, loader.Cancels);
             Assert.IsNotNull(exception);
@@ -516,6 +524,8 @@ namespace FiftyOne.Caching.Tests
 
             // Assert
 
+            Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(0, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);
@@ -557,6 +567,8 @@ namespace FiftyOne.Caching.Tests
 
             // Assert
 
+            Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(1, loader.Cancels);
             Assert.IsNotNull(exception);
@@ -594,6 +606,8 @@ namespace FiftyOne.Caching.Tests
 
             // Assert
 
+            Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(0, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);
@@ -629,6 +643,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(0, loader.Calls);
+            Assert.AreEqual(0, loader.TaskCalls);
             Assert.AreEqual(values.Count, dict.Keys.Count());
         }
 
@@ -663,6 +678,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(0, loader.Calls);
+            Assert.AreEqual(0, loader.TaskCalls);
             Assert.AreEqual(values.Count, dict.Keys.Count());
         }
 
@@ -695,6 +711,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual("four", result);
             Assert.AreEqual(values.Count + 1, dict.Keys.Count());
         }
@@ -728,6 +745,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.IsTrue(success);
             Assert.AreEqual("four", result);
             Assert.AreEqual(values.Count + 1, dict.Keys.Count());
@@ -774,6 +792,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(count, loader.Calls);
+            Assert.AreEqual(count, loader.TaskCalls);
             Assert.AreEqual(count, loader.Cancels);
         }
 
@@ -843,6 +862,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(count, loader.Calls);
+            Assert.AreEqual(count, loader.TaskCalls);
             Assert.AreEqual(count, loader.Cancels);
         }
 
@@ -906,6 +926,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
 
             // Cleanup
 
@@ -943,6 +964,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
 
             // Cleanup
 
@@ -992,6 +1014,7 @@ namespace FiftyOne.Caching.Tests
             Assert.IsTrue(success);
             Assert.IsNull(result);
             Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
         }
     }
 }

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -226,9 +226,9 @@ namespace FiftyOne.Caching.Tests
         {
             // Arrange
 
-            const int baseStepMS = 150;
+            const int baseStepMS = 300;
             var value = "teststring";
-            const int GATE_TIMEOUT_MS = 50;
+            const int GATE_TIMEOUT_MS = 120;
             var sourceForLoader = new CancellationTokenSource();
             Func<CancellationToken, CancellationToken> tokenOverride = _ => sourceForLoader.Token;
             var loader = new ReturnKeyLoader<string>(3 * baseStepMS, tokenOverride, tokenOverride);


### PR DESCRIPTION
- Add `org-name` to workflows.
- Replace `volatile` and `Interlocked` with solid `lock`s in `TrackingLoaderBase`.
- Add `TaskCalls` counter to `TrackingLoaderBase` and check it in tests --- tasks should not start if cancellation token is already cancelled, so the value would differ from `Calls`.
- Add new designated constructor to `TrackingLoaderBase` with two `Func<CancellationToken, CancellationToken>` parameters --- to allow the fake loader to optionally ignore the requesting task's cancellation once loading task was started.
- Add `OnTaskStarted` event to `TrackingLoaderBase` --- to enable tests to await for loading task to actually start before cancelling the token, --- rather than rely on delays and risk cancelling task launch instead of the delay loop.
- Add a test for cancelling the initial `Get` operation (without interrupting the loader task) and receiving the result on the second `Get` call.