### PR TITLE
Add Project URL into Nuget package

### DIFF
--- a/FiftyOne.Caching/FiftyOne.Caching.csproj
+++ b/FiftyOne.Caching/FiftyOne.Caching.csproj
@@ -15,6 +15,7 @@
 	<Copyright>51Degrees Mobile Experts Limited</Copyright>
 	<PackageTags>51degrees,cache,caching,lru</PackageTags>
 	<RepositoryUrl>https://github.com/51Degrees/caching-dotnet</RepositoryUrl>
+	<PackageProjectUrl>https://51degrees.com</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
### Changes
- Set `PackageProjectUrl` to `https://51degrees.com`.

### Why
- https://github.com/51Degrees/device-detection-dotnet/issues/169