### PR TITLE
OPTIM: Only remove a task from the loading dictionary if it actually failed.

### DIFF
--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -626,7 +626,6 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
-            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);

--- a/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
+++ b/FiftyOne.Caching.Tests/LoadingDictionaryTests.cs
@@ -28,6 +28,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -510,16 +511,14 @@ namespace FiftyOne.Caching.Tests
             Assert.AreEqual(1, loader.Calls);
             Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
-            Assert.AreEqual(1, loader.Cancels);
+            Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);
         }
 
         /// <summary>
         /// Test that calling the get method with a cancellation token that
-        /// is already cancelled results in it returning immediately, and
-        /// does not even start the task.
-        /// Also check that the cancellation was passed to the loader properly,
-        /// and that the correct exception is thrown.
+        /// is already cancelled results in it returning immediately.
+        /// Also check that the correct exception is thrown.
         /// </summary>
         [TestMethod]
         public void LoadingDictionary_GetAlreadyCancelled()
@@ -547,7 +546,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
-            Assert.AreEqual(0, loader.TaskCalls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);
@@ -556,8 +555,7 @@ namespace FiftyOne.Caching.Tests
         /// <summary>
         /// Test that calling the cancellation token results in the TryGet method
         /// returning immediately, and not waiting for the Task to complete.
-        /// Also check that the cancellation was passed to the loader properly,
-        /// and that the correct exception is thrown.
+        /// Also check that the correct exception is thrown.
         /// </summary>
         [TestMethod]
         public void LoadingDictionary_TryGetCancelled()
@@ -592,14 +590,13 @@ namespace FiftyOne.Caching.Tests
             Assert.AreEqual(1, loader.Calls);
             Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
-            Assert.AreEqual(1, loader.Cancels);
+            Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);
         }
 
         /// <summary>
         /// Test that calling the TryGet method with a cancellation token that
-        /// is already cancelled results in it returning immediately, and
-        /// does not even start the task.
+        /// is already cancelled results in it returning immediately.
         /// Also check that the cancellation was passed to the loader properly,
         /// and that the correct exception is thrown.
         /// </summary>
@@ -629,7 +626,7 @@ namespace FiftyOne.Caching.Tests
             // Assert
 
             Assert.AreEqual(1, loader.Calls);
-            Assert.AreEqual(0, loader.TaskCalls);
+            Assert.AreEqual(1, loader.TaskCalls);
             Assert.AreEqual(0, loader.CompleteWaits);
             Assert.AreEqual(0, loader.Cancels);
             Assert.IsNotNull(exception);
@@ -775,11 +772,10 @@ namespace FiftyOne.Caching.Tests
 
         /// <summary>
         /// Test that if a call to get is canceled, that the result is
-        /// removed from the dictionary on subsequent requests 
-        /// instead of returning the previously failed result.
+        /// not removed from the dictionary on subsequent requests.
         /// </summary>
         [TestMethod]
-        public void LoadingDictionary_GetCanceledIsNotReused()
+        public void LoadingDictionary_GetCanceledIsReused()
         {
             // Arrange
 
@@ -788,34 +784,29 @@ namespace FiftyOne.Caching.Tests
             var loader = new ReturnKeyLoader<string>(millis);
             var dict = new LoadingDictionary<string, string>(_logger.Object, loader);
             Exception exception = null;
-            var count = 2;
 
             // Act
 
             loader.OnTaskStarted += _ => _token.Cancel();
-            for (int i = 0; i < count; i++)
+            var getter = Task.Run(() => _ = dict[value, _token.Token]);
+            try
             {
-                var getter = Task.Run(() => _ = dict[value, _token.Token]);
-
-                try
-                {
-                    _ = getter.Result;
-                }
-                catch (AggregateException e)
-                {
-                    exception = e.InnerException;
-                }
-                Assert.IsNotNull(exception);
-                exception = null;
-                _token = new CancellationTokenSource();
-                Thread.Sleep(100);
+                _ = getter.Result;
             }
+            catch (AggregateException e)
+            {
+                exception = e.InnerException;
+            }
+            Assert.IsNotNull(exception);
 
+            _token = new CancellationTokenSource();
+            Thread.Sleep(100);
+            Assert.IsNotNull(dict[value, _token.Token]);
             // Assert
 
-            Assert.AreEqual(count, loader.Calls);
-            Assert.AreEqual(count, loader.TaskCalls);
-            Assert.AreEqual(count, loader.Cancels);
+            Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
+            Assert.AreEqual(0, loader.Cancels);
         }
 
         /// <summary>
@@ -851,12 +842,12 @@ namespace FiftyOne.Caching.Tests
         }
 
         /// <summary>
-        /// Test that if a call to TryGet is canceled, that the result is
-        /// removed from the dictionary, and subsequent requests try again
-        /// instead of returning the previously failed result.
+        /// Test that if a call to TryGet is canceled, that the result is not
+        /// removed from the dictionary, and subsequent requests use the previously
+        /// started task.
         /// </summary>
         [TestMethod]
-        public void LoadingDictionary_TryGetCanceledIsRemoved()
+        public void LoadingDictionary_TryGetCanceledIsNotRemoved()
         {
             // Arrange
 
@@ -864,28 +855,24 @@ namespace FiftyOne.Caching.Tests
             var millis = 5000;
             var loader = new ReturnKeyLoader<string>(millis);
             var dict = new LoadingDictionary<string, string>(_logger.Object, loader);
-            var count = 2;
 
             // Act
 
             loader.OnTaskStarted += _ => _token.Cancel();
-            for (int i = 0; i < count; i++)
+            var getter = Task.Run(() => dict.TryGet(value, _token.Token, out _));
+            Assert.ThrowsException<AggregateException>(() =>
             {
-                var getter = Task.Run(() => dict.TryGet(value, _token.Token, out _));
+                _ = getter.Result;
+            });
 
-                Assert.ThrowsException<AggregateException>(() =>
-                {
-                    _ = getter.Result;
-                });
-
-                _token = new CancellationTokenSource();
-            }
+            _token = new CancellationTokenSource();
+            Assert.IsTrue(dict.TryGet(value, _token.Token, out _));
 
             // Assert
 
-            Assert.AreEqual(count, loader.Calls);
-            Assert.AreEqual(count, loader.TaskCalls);
-            Assert.AreEqual(count, loader.Cancels);
+            Assert.AreEqual(1, loader.Calls);
+            Assert.AreEqual(1, loader.TaskCalls);
+            Assert.AreEqual(0, loader.Cancels);
         }
 
         /// <summary>

--- a/FiftyOne.Caching/LoadingDictionary.cs
+++ b/FiftyOne.Caching/LoadingDictionary.cs
@@ -325,14 +325,15 @@ namespace FiftyOne.Caching
             }
             catch(Exception ex)
             {
+
+                // If the operation has been cancelled, then throw this
+                // exception to the caller.
+                cancellationToken.ThrowIfCancellationRequested();
                 // The value is invalid (and may not have an exception in
                 // the Task) so must be removed so that future requests so
                 // that future requests get a new value instead of returning
                 // the invalid one.
                 Remove(key);
-                // If the operation has been cancelled, then throw this
-                // exception to the caller.
-                cancellationToken.ThrowIfCancellationRequested();
                 // If the operation was not cancelled, but did not succeed,
                 // return a KeyNotFoundException with the inner exception
                 // being the exception thrown by the Task (if any).
@@ -446,14 +447,14 @@ namespace FiftyOne.Caching
             {
                 result = _dictionary.GetOrAdd(
                     key,
-                    k => Load(k, cancellationToken));
+                    k => Load(k, CancellationToken.None));
                 result.Value.Wait(cancellationToken);
                 return result.Value;
             }
             catch (Exception ex)
             {
-                Remove(key);
                 cancellationToken.ThrowIfCancellationRequested();
+                Remove(key);
                 ThrowKeyNotFoundException(key, ex);
                 // Note this never returns. It is to satisfy the compiler.
                 return Task.FromResult<TValue>(null);

--- a/FiftyOne.Caching/LoadingDictionary.cs
+++ b/FiftyOne.Caching/LoadingDictionary.cs
@@ -497,7 +497,7 @@ namespace FiftyOne.Caching
         {
             if (_dictionary.TryRemove(key, out _) == false)
             {
-                _logger.LogError($"Failed to remove entry for key '{key}'.");
+                _logger.LogInformation($"Failed to remove entry for key '{key}'.");
             }
         }
     }

--- a/FiftyOne.Caching/LoadingDictionary.cs
+++ b/FiftyOne.Caching/LoadingDictionary.cs
@@ -85,6 +85,11 @@ namespace FiftyOne.Caching
         private readonly ILogger<LoadingDictionary<TKey, TValue>> _logger;
 
         /// <summary>
+        /// Timeout to use for internal load tasks.
+        /// </summary>
+        private readonly TimeSpan _taskTimeout;
+
+        /// <summary>
         /// Constructor.
         /// </summary>
         /// <param name="logger">
@@ -103,17 +108,23 @@ namespace FiftyOne.Caching
         /// <param name="capacity">
         /// The initial number of elements that the can contain.
         /// </param>
+        /// <param name="taskTimeoutSeconds">
+        /// Number of seconds to let internal tasks run for before cancelling completely.
+        /// This is separate from the cancelation of a get.
+        /// </param>
         public LoadingDictionary(
             ILogger<LoadingDictionary<TKey, TValue>> logger,
             IValueTaskLoader<TKey, TValue> loader,
             ICollection<KeyValuePair<TKey, TValue>> initial,
             int concurrencyLevel,
-            int capacity)
+            int capacity,
+            int taskTimeoutSeconds = 30)
             : this(
                   logger,
                   loader,
                   new ConcurrentDictionary<TKey, Lazy<Task<TValue>>>(concurrencyLevel, capacity),
-                  initial)
+                  initial,
+                  taskTimeoutSeconds)
         { }
 
         /// <summary>
@@ -128,15 +139,21 @@ namespace FiftyOne.Caching
         /// <param name="initial">
         /// Collection of initial values to pre-populate the dictionary with.
         /// </param>
+        /// <param name="taskTimeoutSeconds">
+        /// Number of seconds to let internal tasks run for before cancelling completely.
+        /// This is separate from the cancelation of a get.
+        /// </param>
         public LoadingDictionary(
             ILogger<LoadingDictionary<TKey, TValue>> logger,
             IValueTaskLoader<TKey, TValue> loader,
-            ICollection<KeyValuePair<TKey, TValue>> initial)
+            ICollection<KeyValuePair<TKey, TValue>> initial,
+            int taskTimeoutSeconds = 30)
             : this(
                   logger,
                   loader,
                   new ConcurrentDictionary<TKey, Lazy<Task<TValue>>>(),
-                  initial)
+                  initial,
+                  taskTimeoutSeconds)
         {
         }
 
@@ -189,11 +206,13 @@ namespace FiftyOne.Caching
             ILogger<LoadingDictionary<TKey, TValue>> logger,
             IValueTaskLoader<TKey, TValue> loader,
             ConcurrentDictionary<TKey, Lazy<Task<TValue>>> dictionary,
-            ICollection<KeyValuePair<TKey, TValue>> initial = null)
+            ICollection<KeyValuePair<TKey, TValue>> initial = null,
+            int taskTimeoutSeconds = 30)
         {
             _logger = logger;
             _dictionary = dictionary;
             _loader = loader;
+            _taskTimeout = TimeSpan.FromSeconds(taskTimeoutSeconds);
             if (initial != null)
             {
                 foreach (var pair in initial)
@@ -321,7 +340,10 @@ namespace FiftyOne.Caching
             // First try at getting the task.
             try
             {
-                return await GetAndWait(key, cancellationToken);
+                return await GetAndWait(
+                    key,
+                    cancellationToken,
+                    new CancellationTokenSource(_taskTimeout).Token);
             }
             catch(Exception ex)
             {
@@ -428,8 +450,11 @@ namespace FiftyOne.Caching
         /// <param name="key">
         /// Key to get the value Task for.
         /// </param>
-        /// <param name="cancellationToken">
-        /// Cancellation token to pass to the load method, and the wait method.
+        /// <param name="waitToken">
+        /// Cancellation token to pass to the wait method.
+        /// </param>
+        /// <param name="taskToken">
+        /// Cancellation token to pass to the load method.
         /// </param>
         /// <returns>
         /// New or existing Task which will produce a value for the key.
@@ -440,20 +465,20 @@ namespace FiftyOne.Caching
         /// <exception cref="AggregateException">
         /// If there was an exception thrown from the Task.
         /// </exception>
-        private Task<TValue> GetAndWait(TKey key, CancellationToken cancellationToken)
+        private Task<TValue> GetAndWait(TKey key, CancellationToken waitToken, CancellationToken taskToken)
         {
             Lazy<Task<TValue>> result = null;
             try
             {
                 result = _dictionary.GetOrAdd(
                     key,
-                    k => Load(k, CancellationToken.None));
-                result.Value.Wait(cancellationToken);
+                    k => Load(k, taskToken));
+                result.Value.Wait(waitToken);
                 return result.Value;
             }
             catch (Exception ex)
             {
-                cancellationToken.ThrowIfCancellationRequested();
+                waitToken.ThrowIfCancellationRequested();
                 Remove(key);
                 ThrowKeyNotFoundException(key, ex);
                 // Note this never returns. It is to satisfy the compiler.


### PR DESCRIPTION
If it was just cancelled, let the task run otherwise it could just timeout again the next time.