### PR TITLE
BUG: Change options.json ubuntu-latest to ubuntu 22.04 

### DIFF
--- a/ci/options.json
+++ b/ci/options.json
@@ -1,6 +1,6 @@
 [  
     {
-        "Image": "ubuntu-latest",
+        "Image": "ubuntu-22.04",
         "Name": "Ubuntu_Any_CPU_Release",
         "Configuration": "Release",
         "Arch": "Any CPU",
@@ -8,7 +8,7 @@
         "BuildMethod": "dotnet"
     },
     {
-        "Image": "ubuntu-latest",
+        "Image": "ubuntu-22.04",
         "Name": "Ubuntu_Any_CPU_Debug",
         "Configuration": "Debug",
         "Arch": "Any CPU",


### PR DESCRIPTION
This change makes sure .NET 6 stays supported as ubuntu ;atest(24) only supports .NET 8